### PR TITLE
docs: updated links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/fossasia/pslab-hardware.svg?branch=master)](https://travis-ci.org/fossasia/pslab-hardware)
 [![Gitter](https://badges.gitter.im/fossasia/pslab.svg)](https://gitter.im/fossasia/pslab?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
-This repository holds [PSLab](http://pslab.fossasia.org/) hardware design files. PSLab is a tiny pocket science lab that provides an array of equipment for doing science and engineering experiments. It can function like an oscilloscope, waveform generator, frequency counter, programmable voltage and current source and also as a data logger. The first version of hardware (v1) was developed by [Jithin B P](https://github.com/jithinbp), a core developer of PSLab Project. Later versions were developed by [Padmal](https://github.com/CloudyPadmal).
+This repository holds [PSLab](https://pslab.io) hardware design files. PSLab is a tiny pocket science lab that provides an array of equipment for doing science and engineering experiments. It can function like an oscilloscope, waveform generator, frequency counter, programmable voltage and current source and also as a data logger. The first version of hardware (v1) was developed by [Jithin B P](https://github.com/jithinbp), a core developer of PSLab Project. Later versions were developed by [Padmal](https://github.com/CloudyPadmal).
 
 ## Communication
 Our chat channel is on Gitter here at [PSLab](https://gitter.im/fossasia/pslab)


### PR DESCRIPTION
Fixes #50 

We have to update the link in repository description
![link](https://user-images.githubusercontent.com/14261304/44002974-f1d03558-9e68-11e8-90d6-83d0fab22bc9.png)
